### PR TITLE
:bug: prototypeと実引数が一致していない問題を修正

### DIFF
--- a/mc_logwatcher.c
+++ b/mc_logwatcher.c
@@ -19,7 +19,7 @@
 #define EVENT_BUF_LEN     ( 1024 * ( EVENT_SIZE + 16 ) )
 
 //プロトタイプ
-void sigproc();
+void sigproc(int);
 void sendMessage(int *, struct sockaddr_in *,char *, const unsigned char);
 void sendtoKayac(char *);
 void urlEncode(char *, const char *);


### PR DESCRIPTION
実装をベースに調整しました。

``` c
// 22行目
void sigproc();

// 258行目
void sigproc(int sig){
```
